### PR TITLE
Allow custom Puppeteer renderer config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,49 @@ in order to add more paths, add an array of strings corresponding to the paths y
 }
 ```
 
+### Render configuration
+
+You can configure the renderer (browser) options by using the following example config:
+
+```json
+{
+  "prerender": {
+    "routes": ["/", "/about"],
+    "rendererConfig": {
+      "renderAfterDocumentEvent": "prerender-trigger"
+    }
+  }
+}
+```
+
+This is particularly useful if you'd like to pre-fetch some API data or async config
+and make that part of your pre-rendered HTML.
+
+In the example above, the `/` and `/about` pages will only be rendered when the custom DOM event `prerender-trigger` is dispatched.
+
+You can do so in your code like the following:
+
+```js
+document.dispatchEvent(new Event('prerender-trigger'));
+```
+
+The custom configuration can also be useful for debugging. If the resulting html does not look like what you're expecting you could use the following configuration:
+
+```json
+{
+  "prerender": {
+    "routes": ["/", "/about"],
+    "rendererConfig": {
+      "headless": false
+    }
+  }
+}
+```
+
+To make the pre-render browser visible and you would be available to debug.
+
+To see all the options available see this [documentation](https://github.com/Tribex/prerenderer#prerendererrenderer-puppeteer-options)
+
 ## What is Prerendering?
 
 To quote [prerender-spa-plugin](https://github.com/chrisvfritz/prerender-spa-plugin/blob/master/README.md):
@@ -46,7 +89,3 @@ To quote [prerender-spa-plugin](https://github.com/chrisvfritz/prerender-spa-plu
 
 Currently only `@prerenderer/renderer-puppeteer` is supported, although `@prerenderer/renderer-jsdom` 
 will probably be supported in the future
-
-## More options
-
-More options are planned for passing through to the prerenderer.

--- a/index.js
+++ b/index.js
@@ -8,18 +8,20 @@ const Puppeteer = require('@prerenderer/renderer-puppeteer');
 module.exports = bundler => {
   bundler.on('buildEnd', async () => {
     if (process.env.NODE_ENV !== 'production') return;
-    const { outDir } = bundler.options;
-    const prerenderer = new Prerenderer({
-      staticDir: outDir,
-      renderer: new Puppeteer(),
-    });
     let routes = ['/']; // the default route
     const found = await cosmiconfig('prerender').search();
     if (found) {
       const { config } = found;
       if (Array.isArray(config)) routes = config;
-      else ({ routes } = config);
+      else ({ routes, rendererConfig } = config);
+
+      rendererConfig = rendererConfig || {};
     }
+    const { outDir } = bundler.options;
+    const prerenderer = new Prerenderer({
+      staticDir: outDir,
+      renderer: new Puppeteer(rendererConfig),
+    });
     console.log('\nRendering...');
     try {
       await prerenderer.initialize();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel-plugin-prerender",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "parcel-plugin",
     "static-site-generator"
   ],
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Hello!

Quite like this package, and adds to the "just works" parcel wonder

However for some SPA's the render is triggered before some desirable events have happened (such as an initializing API request or something of the sort)

Also this opens the opportunity to not use headless mode which can be useful to debug if things don't work as expected